### PR TITLE
remove tf dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,6 @@ spacy==2.1.3
 statsmodels==0.11.1
 tensorboard==1.15.0
 tensorboardX==1.6
-tensorflow-estimator==1.15.1
-tensorflow==1.15.4
 torch==1.3.1
 torchvision==0.4.2
 tqdm==4.32.2


### PR DESCRIPTION
This removes the dependency on TF because there's an [outstanding vulnerability in this version of TF](https://github.com/advisories/GHSA-xwhf-g6j5-j5gc) and I can't see any code in this repo that imports tensorflow or tensorflow_estimator.

If it breaks the deployed demos, we'll roll back ¯\\\_(ツ)\_/¯